### PR TITLE
Add EOL-QC tool contract and draft pipeline

### DIFF
--- a/custom_pipelines.py
+++ b/custom_pipelines.py
@@ -58,10 +58,10 @@ def to_bs():
 def to_bs():
     """EOL QC custom resequencing pipeline"""
 
-    b1 = [(Constants.ENTRY_DS_SUBREAD, 'pbsmrtpipe_internal.tasks.eol_qc:0'),
-          (Constants.ENTRY_DS_ALIGN, 'pbsmrtpipe_internal.tasks.eol_qc:1')]
+    b1 = [(Constants.ENTRY_DS_SUBREAD, 'pbinternal2.tasks.eol_qc:0'),
+          (Constants.ENTRY_DS_ALIGN, 'pbinternal2.tasks.eol_qc:1')]
           #("pbsmrtpipe.pipelines.sa3_ds_resequencing_fat:pbalign.tasks.pbalign:0",
-          # 'pbinternal2.tasks.eol_qc_stats:1')]
+          # 'pbinternal2.tasks.eol_qc:1')]
     return b1
 
 

--- a/custom_pipelines.py
+++ b/custom_pipelines.py
@@ -54,7 +54,7 @@ def to_bs():
     return b3
 
 
-@registry("internal_eol_qc_stats", "EOL QC resequencing pipeline", "0.1.0", tags=(Tags.INTERNAL))
+@registry("internal_eol_qc_stats", "EOL QC resequencing pipeline", "0.1.0", tags=(Tags.INTERNAL,))
 def to_bs():
     """EOL QC custom resequencing pipeline"""
 

--- a/custom_pipelines.py
+++ b/custom_pipelines.py
@@ -54,6 +54,16 @@ def to_bs():
     return b3
 
 
+@registry("internal_eol_qc_stats", "EOL QC resequencing pipeline", "0.1.0", tags=(Tags.INTERNAL))
+def to_bs():
+    """EOL QC custom resequencing pipeline"""
+
+    b3 = [(Constants.ENTRY_DS_SUBREAD, 'pbinternal2.tasks.eol_qc_stats:0'),
+          ("pbsmrtpipe.pipelines.sa3_ds_resequencing_fat:pbalign.tasks.pbalign:0",
+           'pbinternal2.tasks.eol_qc_stats:1')]
+    return b3
+
+
 @registry("internal_cond_dev", "Dev Reseq Cond Report", "0.2.0", tags=C.TAGS_DEFAULT)
 def to_bs():
     """Hello World test for Conditions JSON"""

--- a/custom_pipelines.py
+++ b/custom_pipelines.py
@@ -58,10 +58,11 @@ def to_bs():
 def to_bs():
     """EOL QC custom resequencing pipeline"""
 
-    b3 = [(Constants.ENTRY_DS_SUBREAD, 'pbinternal2.tasks.eol_qc_stats:0'),
-          ("pbsmrtpipe.pipelines.sa3_ds_resequencing_fat:pbalign.tasks.pbalign:0",
-           'pbinternal2.tasks.eol_qc_stats:1')]
-    return b3
+    b1 = [(Constants.ENTRY_DS_SUBREAD, 'pbsmrtpipe_internal.tasks.eol_qc:0'),
+          (Constants.ENTRY_DS_ALIGN, 'pbsmrtpipe_internal.tasks.eol_qc:1')]
+          #("pbsmrtpipe.pipelines.sa3_ds_resequencing_fat:pbalign.tasks.pbalign:0",
+          # 'pbinternal2.tasks.eol_qc_stats:1')]
+    return b1
 
 
 @registry("internal_cond_dev", "Dev Reseq Cond Report", "0.2.0", tags=C.TAGS_DEFAULT)

--- a/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
+++ b/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
@@ -11,7 +11,7 @@
                 {
                     "index": 1, 
                     "instanceId": 0, 
-                    "taskTypeId": "pbsmrtpipe_internal.tasks.eol_qc"
+                    "taskTypeId": "pbinternal2.tasks.eol_qc"
                 }
             ]
         }, 
@@ -23,7 +23,7 @@
                 {
                     "index": 0, 
                     "instanceId": 0, 
-                    "taskTypeId": "pbsmrtpipe_internal.tasks.eol_qc"
+                    "taskTypeId": "pbinternal2.tasks.eol_qc"
                 }
             ]
         }
@@ -44,7 +44,7 @@
         {
             "default": 32768, 
             "description": "Option nreads description", 
-            "id": "pbsmrtpipe_internal.task_options.nreads", 
+            "id": "pbinternal2.task_options.nreads", 
             "name": "Option nreads", 
             "optionTypeId": "pbsmrtpipe.option_types.integer"
         }

--- a/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
+++ b/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
@@ -1,0 +1,53 @@
+{
+    "_comment": "Created pipeline pbpipelines_internal.pipelines.internal_eol_qc_stats with pbsmrtpipe v0.42.1", 
+    "bindings": [], 
+    "description": "EOL QC custom resequencing pipeline", 
+    "entryPoints": [
+        {
+            "entryId": "eid_alignment", 
+            "fileTypeId": "PacBio.DataSet.AlignmentSet", 
+            "name": "Entry Name: PacBio.DataSet.AlignmentSet", 
+            "tasks": [
+                {
+                    "index": 1, 
+                    "instanceId": 0, 
+                    "taskTypeId": "pbsmrtpipe_internal.tasks.eol_qc"
+                }
+            ]
+        }, 
+        {
+            "entryId": "eid_subread", 
+            "fileTypeId": "PacBio.DataSet.SubreadSet", 
+            "name": "Entry Name: PacBio.DataSet.SubreadSet", 
+            "tasks": [
+                {
+                    "index": 0, 
+                    "instanceId": 0, 
+                    "taskTypeId": "pbsmrtpipe_internal.tasks.eol_qc"
+                }
+            ]
+        }
+    ], 
+    "id": "pbpipelines_internal.pipelines.internal_eol_qc_stats", 
+    "name": "EOL QC resequencing pipeline", 
+    "options": [], 
+    "tags": [
+        "a", 
+        "e", 
+        "i", 
+        "l", 
+        "n", 
+        "r", 
+        "t"
+    ], 
+    "taskOptions": [
+        {
+            "default": 32768, 
+            "description": "Option nreads description", 
+            "id": "pbsmrtpipe_internal.task_options.nreads", 
+            "name": "Option nreads", 
+            "optionTypeId": "pbsmrtpipe.option_types.integer"
+        }
+    ], 
+    "version": "0.1.0"
+}

--- a/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
+++ b/resolved-pipeline-templates/pbpipelines_internal.pipelines.internal_eol_qc_stats_pipeline_template.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Created pipeline pbpipelines_internal.pipelines.internal_eol_qc_stats with pbsmrtpipe v0.42.1", 
+    "_comment": "Created pipeline pbpipelines_internal.pipelines.internal_eol_qc_stats with pbsmrtpipe v0.42.2", 
     "bindings": [], 
     "description": "EOL QC custom resequencing pipeline", 
     "entryPoints": [
@@ -32,13 +32,7 @@
     "name": "EOL QC resequencing pipeline", 
     "options": [], 
     "tags": [
-        "a", 
-        "e", 
-        "i", 
-        "l", 
-        "n", 
-        "r", 
-        "t"
+        "internal"
     ], 
     "taskOptions": [
         {

--- a/testkit-data/eol_qc_stats_01/preset.xml
+++ b/testkit-data/eol_qc_stats_01/preset.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<pipeline-template-preset id="MyPreset">
+
+    <!-- Default Workflow level Options -->
+    <options>
+    <!-- workflow level options. Same as with the Protocol -->
+        <option id="pbsmrtpipe.options.max_total_nproc" >
+            <value>1000</value>
+        </option>
+
+        <!-- MAX Number of Processors -->
+        <option id="pbsmrtpipe.options.max_nproc">
+            <value>24</value>
+        </option>
+
+        <!-- Disable chunk mode -->
+        <option id="pbsmrtpipe.options.chunk_mode" >
+            <value>False</value>
+        </option>
+
+        <!-- MAX Number of Chunks -->
+        <option id="pbsmrtpipe.options.max_nchunks">
+            <value>24</value>
+        </option>
+
+        <option id="pbsmrtpipe.options.cluster_manager" >
+            <value>pbsmrtpipe.cluster_templates.sge</value>
+        </option>
+
+    </options>
+
+    <!-- Default Task specific Options -->
+    <task-options>
+        <option id="pbsmrtpipe.task_options.dev_message">
+            <value>My Custom Preset Message from preset.xml</value>
+        </option>
+	<!-- This is specifically for testing failures, set to < 0 to raise ValueError -->
+        <option id="pbsmrtpipe.task_options.dev_fasta_min_length">
+            <value>25</value>
+        </option>
+    </task-options>
+
+</pipeline-template-preset>

--- a/testkit-data/eol_qc_stats_01/preset.xml
+++ b/testkit-data/eol_qc_stats_01/preset.xml
@@ -34,6 +34,9 @@
         <option id="pbsmrtpipe.task_options.dev_message">
             <value>My Custom Preset Message from preset.xml</value>
         </option>
+        <option id="pbinternal2.task_options.nreads">
+            <value>16</value>
+        </option>
 	<!-- This is specifically for testing failures, set to < 0 to raise ValueError -->
         <option id="pbsmrtpipe.task_options.dev_fasta_min_length">
             <value>25</value>

--- a/testkit-data/eol_qc_stats_01/testkit.cfg
+++ b/testkit-data/eol_qc_stats_01/testkit.cfg
@@ -9,7 +9,10 @@ pipeline_xml = workflow_id.xml
 preset_xml = preset.xml
 
 [entry_points]
+# TODO(mdsmith 7-28-2016): replace this with complete, protected eol-qc data when available
 eid_subread = /pbi/collections/315/3150273/r54011_20160626_175116/3_C01/m54011_160627_083157.subreadset.xml
+# TODO(mdsmith 7-28-2016): remove this when the resequencing portion of the pipeline is added
+eid_alignment = /pbi/dept/secondary/siv/smrtlink/smrtlink-beta/smrtsuite_166987/userdata/jobs_root/013/013501/tasks/pbcoretools.tasks.gather_alignmentset-1/file.alignmentset.xml
 
 [tests]
 # Tests can be loaded from any python module

--- a/testkit-data/eol_qc_stats_01/testkit.cfg
+++ b/testkit-data/eol_qc_stats_01/testkit.cfg
@@ -1,0 +1,17 @@
+[pbsmrtpipe:pipeline]
+
+id = eol_qc_stats_01
+description = Example eol_qc resequencing pipeline
+author = mdsmith
+
+
+pipeline_xml = workflow_id.xml
+preset_xml = preset.xml
+
+[entry_points]
+eid_subread = /pbi/collections/315/3150273/r54011_20160626_175116/3_C01/m54011_160627_083157.subreadset.xml
+
+[tests]
+# Tests can be loaded from any python module
+# specifically, Any TestBase subclass in pbsmrtpipe.teskit.core.test_zero will be loaded
+pbsmrtpipe.testkit.core = test_zero, test_resources, test_datastore

--- a/testkit-data/eol_qc_stats_01/workflow_id.xml
+++ b/testkit-data/eol_qc_stats_01/workflow_id.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pipeline-template>
+
+    <!-- Reference a workflow template defined in -->
+    <import-template id="pbpipelines_internal.pipelines.eol_qc_resequencing" />
+
+    <options>
+    <!-- workflow level options  -->
+        <option id="pbsmrtpipe.options.max_nchunks" >
+            <value>7</value>
+        </option>
+        <option id="pbsmrtpipe.options.max_nproc" >
+            <value>13</value>
+        </option>
+    </options>
+
+    <!-- task level options here -->
+    <task-options>
+        <option id="pbsmrtpipe.task_option.option_id1">
+            <value>1234</value>
+        </option>
+        <option id="pbsmrtpipe.task_option.option_id2">
+        <value>abcd</value>
+        </option>
+    </task-options>
+
+</pipeline-template>

--- a/testkit-data/eol_qc_stats_01/workflow_id.xml
+++ b/testkit-data/eol_qc_stats_01/workflow_id.xml
@@ -2,7 +2,7 @@
 <pipeline-template>
 
     <!-- Reference a workflow template defined in -->
-    <import-template id="pbpipelines_internal.pipelines.eol_qc_resequencing" />
+    <import-template id="pbpipelines_internal.pipelines.internal_eol_qc_stats" />
 
     <options>
     <!-- workflow level options  -->

--- a/tool-contracts/pbinternal2.tasks.eol_qc_tool_contract.json
+++ b/tool-contracts/pbinternal2.tasks.eol_qc_tool_contract.json
@@ -6,7 +6,7 @@
     },
     "tool_contract": {
         "_comment": "Created by v0.4.3",
-        "description": "Quick tool eol_qc pbsmrtpipe_internal.tasks.eol_qc",
+        "description": "Quick tool eol_qc pbinternal2.tasks.eol_qc",
         "input_types": [
             {
                 "description": "description for PacBio.DataSet.SubreadSet_0",
@@ -48,11 +48,11 @@
                     "default": 32768,
                     "description": "Option nreads description",
                     "name": "Option nreads",
-                    "option_id": "pbsmrtpipe_internal.task_options.nreads",
+                    "option_id": "pbinternal2.task_options.nreads",
                     "type": "integer"
                 },
                 "properties": {
-                    "pbsmrtpipe_internal.task_options.nreads": {
+                    "pbinternal2.task_options.nreads": {
                         "default": 32768,
                         "description": "Option nreads description",
                         "title": "Option nreads",
@@ -60,15 +60,15 @@
                     }
                 },
                 "required": [
-                    "pbsmrtpipe_internal.task_options.nreads"
+                    "pbinternal2.task_options.nreads"
                 ],
-                "title": "JSON Schema for pbsmrtpipe_internal.task_options.nreads",
+                "title": "JSON Schema for pbinternal2.task_options.nreads",
                 "type": "object"
             }
         ],
         "task_type": "pbsmrtpipe.task_types.standard",
-        "tool_contract_id": "pbsmrtpipe_internal.tasks.eol_qc"
+        "tool_contract_id": "pbinternal2.tasks.eol_qc"
     },
-    "tool_contract_id": "pbsmrtpipe_internal.tasks.eol_qc",
+    "tool_contract_id": "pbinternal2.tasks.eol_qc",
     "version": "0.1.0"
 }

--- a/tool-contracts/pbinternal2.tasks.eol_qc_tool_contract.json
+++ b/tool-contracts/pbinternal2.tasks.eol_qc_tool_contract.json
@@ -1,0 +1,74 @@
+{
+    "driver": {
+        "env": {},
+        "exe": "python -m pbinternal2.tasks.eol_qc run-rtc  ",
+        "serialization": "json"
+    },
+    "tool_contract": {
+        "_comment": "Created by v0.4.3",
+        "description": "Quick tool eol_qc pbsmrtpipe_internal.tasks.eol_qc",
+        "input_types": [
+            {
+                "description": "description for PacBio.DataSet.SubreadSet_0",
+                "file_type_id": "PacBio.DataSet.SubreadSet",
+                "id": "Label PacBio.DataSet.SubreadSet_0",
+                "title": "<DataSetFileType id=PacBio.DataSet.SubreadSet name=file >"
+            },
+            {
+                "description": "description for PacBio.DataSet.AlignmentSet_1",
+                "file_type_id": "PacBio.DataSet.AlignmentSet",
+                "id": "Label PacBio.DataSet.AlignmentSet_1",
+                "title": "<DataSetFileType id=PacBio.DataSet.AlignmentSet name=file >"
+            }
+        ],
+        "is_distributed": true,
+        "name": "Tool eol_qc",
+        "nproc": 1,
+        "output_types": [
+            {
+                "default_name": "file",
+                "description": "description for <FileType id=PacBio.FileTypes.csv name=file >",
+                "file_type_id": "PacBio.FileTypes.csv",
+                "id": "Label PacBio.FileTypes.csv_0",
+                "title": "<FileType id=PacBio.FileTypes.csv name=file >"
+            },
+            {
+                "default_name": "file",
+                "description": "description for <FileType id=PacBio.FileTypes.csv name=file >",
+                "file_type_id": "PacBio.FileTypes.csv",
+                "id": "Label PacBio.FileTypes.csv_1",
+                "title": "<FileType id=PacBio.FileTypes.csv name=file >"
+            }
+        ],
+        "resource_types": [],
+        "schema_options": [
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "pb_option": {
+                    "default": 32768,
+                    "description": "Option nreads description",
+                    "name": "Option nreads",
+                    "option_id": "pbsmrtpipe_internal.task_options.nreads",
+                    "type": "integer"
+                },
+                "properties": {
+                    "pbsmrtpipe_internal.task_options.nreads": {
+                        "default": 32768,
+                        "description": "Option nreads description",
+                        "title": "Option nreads",
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "pbsmrtpipe_internal.task_options.nreads"
+                ],
+                "title": "JSON Schema for pbsmrtpipe_internal.task_options.nreads",
+                "type": "object"
+            }
+        ],
+        "task_type": "pbsmrtpipe.task_types.standard",
+        "tool_contract_id": "pbsmrtpipe_internal.tasks.eol_qc"
+    },
+    "tool_contract_id": "pbsmrtpipe_internal.tasks.eol_qc",
+    "version": "0.1.0"
+}


### PR DESCRIPTION
Still need to add resequencing to pipeline, but the single task version works with the supplied testkit.cfg.